### PR TITLE
Foundry v10 and dnd5e 2.0.0 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,9 +1,8 @@
 {
-  "name": "apply-self-effects-5e",
+  "id": "apply-self-effects-5e",
   "title": "Apply Self Effects DnD5e",
   "description": "A module which allows a GM to interact with effects on rolled items from chat.",
   "version": "1.0.2",
-  "author": "Andrew Krigline",
   "authors": [
     {
       "name": "Andrew Krigline",
@@ -13,20 +12,25 @@
       "patreon": "ElfFriend_DnD"
     }
   ],
-  "system": [ "dnd5e" ],
   "scripts": [
     "./scripts/apply-self-effects-5e.js"
   ],
-  "dependencies": [
-    {
-      "name": "more-hooks-5e"
-    },
-    {
-      "name": "lib-wrapper"
-    }
-  ],
-  "minimumCoreVersion": "0.8.9",
-  "compatibleCoreVersion": "9",
+  "relationships": {
+    "systems": [{
+      "id": "dnd5e",
+      "type": "system",
+      "compatibility": {
+        "minimum": "2.0.0"
+      }
+    }],
+    "requires": [{
+      "id": "lib-wrapper",
+      "type": "module"
+    }]
+  },
+  "compatibility": {
+    "minimum": 10
+  },
   "url": "https://github.com/ElfFriend-DnD/foundryvtt-apply-self-effects-5e",
   "bugs": "https://github.com/ElfFriend-DnD/foundryvtt-apply-self-effects-5e/issues",
   "changelog": "https://github.com/ElfFriend-DnD/foundryvtt-apply-self-effects-5e/releases",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "apply-self-effects-5e",
   "title": "Apply Self Effects DnD5e",
   "description": "A module which allows a GM to interact with effects on rolled items from chat.",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "authors": [
     {
       "name": "Andrew Krigline",

--- a/scripts/apply-self-effects-5e.js
+++ b/scripts/apply-self-effects-5e.js
@@ -16,7 +16,7 @@ class ApplySelfEffects5e {
    * @returns 
    */
    static handleUseItem = async (item) => {
-    if (item.data.data.target?.type !== 'self' || !item.effects.size) {
+    if (item.system.target?.type !== 'self' || !item.effects.size) {
       return;
     }
 
@@ -29,8 +29,8 @@ class ApplySelfEffects5e {
     this.log('apply this to the parent', item, actor);
 
     const existingDisabledEffects = actor.effects.filter((effect) => {
-      const isFromThisItem = effect.data.origin === item.uuid;
-      const isDisabled = effect.data.disabled;
+      const isFromThisItem = effect.origin === item.uuid;
+      const isDisabled = effect.disabled;
       const isTemporary = effect.isTemporary;
 
       return isFromThisItem && isTemporary && isDisabled;
@@ -42,7 +42,7 @@ class ApplySelfEffects5e {
       const actorEffectUpdates = existingDisabledEffects
       .map((effect) => {
         return {
-          _id: effect.data._id,
+          _id: effect.id,
           disabled: false,
         }
       });
@@ -53,7 +53,7 @@ class ApplySelfEffects5e {
     // otherwise, create new temporary effects from the item on the parent actor
     
     const effectsToApply = item.effects.filter((effect) => {
-      return effect.isTemporary && !(effect.data.enabled && effect.data.transfer)
+      return effect.isTemporary && !(effect.enabled && effect.transfer)
       // if the effect is enabled and transferred, we assume it already is on the actor
     });
 

--- a/scripts/apply-self-effects-5e.js
+++ b/scripts/apply-self-effects-5e.js
@@ -9,13 +9,13 @@ class ApplySelfEffects5e {
   }
   
   /**
-   * When an item that targets self is rolled:
+   * When an item that targets self is used:
    * if the parent actor has any disabled temporary effects from this item, activate them
    * otherwise apply any temporary effects to the parent actor
    * @param {*} item 
    * @returns 
    */
-   static handleItemRoll = async (item) => {
+   static handleUseItem = async (item) => {
     if (item.data.data.target?.type !== 'self' || !item.effects.size) {
       return;
     }
@@ -89,7 +89,7 @@ Hooks.on("ready", async () => {
   console.log(`${ApplySelfEffects5e.MODULE_NAME} | Initializing ${ApplySelfEffects5e.MODULE_TITLE}`);
 
   // initialize item hooks
-  Hooks.on('Item5e.roll', ApplySelfEffects5e.handleItemRoll);
+  Hooks.on('dnd5e.useItem', ApplySelfEffects5e.handleUseItem);
 });
 
 Hooks.once('devModeReady', ({ registerPackageDebugFlag }) => {


### PR DESCRIPTION
Make the module compatible with Foundry v10 and the dnd5e version that's compatible with it

- updates to the manifest file
- switch from `more-hooks-5e` to the new hooks the dnd5e system has
- remove `.data` uses